### PR TITLE
Resolve TODOs around streams and tests

### DIFF
--- a/runtime/datetime/timelib_wrapper.cpp
+++ b/runtime/datetime/timelib_wrapper.cpp
@@ -12,6 +12,7 @@
 #include "runtime/context/runtime-context.h"
 #include "server/php-engine-vars.h"
 #include "server/php-runner.h"
+#include "runtime/datetime/datetime_functions.h"
 
 // these constants are a part of the private timelib API, but PHP uses them internally;
 // we define them here locally
@@ -302,8 +303,7 @@ std::pair<timelib_time*, string> php_timelib_date_initialize(const string& tz_na
   } else if (t->tz_info) {
     tzi = t->tz_info;
   } else {
-    // TODO: use f$date_default_timezone_get()
-    tzi = vk::singleton<TzinfoCache>::get().get_tzinfo(PHP_TIMELIB_TZ_MOSCOW);
+    tzi = vk::singleton<TzinfoCache>::get().get_tzinfo(f$date_default_timezone_get().c_str());
   }
 
   timelib_time* now = timelib_time_ctor();

--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -141,7 +141,7 @@ bool f$chmod(const string& s, int64_t mode) {
 }
 
 void f$clearstatcache() {
-  // TODO
+  // No stat cache is implemented in KPHP runtime, so nothing to clear.
 }
 
 bool f$copy(const string& from, const string& to) {

--- a/runtime/instance-copy-processor.cpp
+++ b/runtime/instance-copy-processor.cpp
@@ -18,9 +18,7 @@ bool InstanceDeepCopyVisitor::process(string& str) noexcept {
     return true;
   }
 
-  // TODO: it seems we can use `str.estimate_memory_usage(str.size())` here,
-  //  because we don't need to take capacity into the account, only size.
-  if (unlikely(!is_enough_memory_for(str.estimate_memory_usage()))) {
+  if (unlikely(!is_enough_memory_for(str.estimate_memory_usage(str.size())))) {
     str = string();
     memory_limit_exceeded_ = true;
     return false;

--- a/runtime/net_events.cpp
+++ b/runtime/net_events.cpp
@@ -141,7 +141,7 @@ kphp_event_timer* allocate_event_timer(double wakeup_time, int wakeup_callback_i
 void remove_event_timer(kphp_event_timer* et) {
   int i = (et->heap_index & EVENT_TIMERS_HEAP_INDEX_MASK);
   php_assert(i > 0 && i <= event_timers_heap_size && event_timers_heap[i] == et);
-  et->heap_index = 0; // TODO remove after testing
+  et->heap_index = 0;
   dl::deallocate(et, sizeof(kphp_event_timer));
 
   et = event_timers_heap[event_timers_heap_size--];
@@ -167,7 +167,7 @@ int remove_expired_event_timers() {
 }
 
 int wait_net(int timeout_ms) {
-  bool some_expires = false; // TODO remove assert
+  bool some_expires = false;
   double begin_time = get_precise_now();
   double expire_event_time = 0.0;
   //  fprintf (stderr, "wait_net_begin\n");

--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -777,7 +777,7 @@ static Stream ssl_stream_socket_client(const string& url, int64_t& error_number,
   SSL_set_tlsext_host_name(ssl_handle, host.c_str());
 #endif
 
-  SSL_set_connect_state(ssl_handle); // TODO remove
+
 
   while (true) {
     int connect_result = SSL_connect(ssl_handle);
@@ -1069,12 +1069,14 @@ bool ssl_stream_set_option(const Stream& stream, int64_t option, int64_t value) 
   case STREAM_SET_WRITE_BUFFER_OPTION:
   case STREAM_SET_READ_BUFFER_OPTION:
     if (value != 0) {
-      // TODO
-      //         BIO_set_read_buffer_size (SSL_get_rbio (c->ssl_handle), value);
-      //         BIO_set_write_buffer_size (SSL_get_wbio (c->ssl_handle), value);
-
-      php_warning("SSL wrapper doesn't support buffered input/output");
-      return false;
+      BIO* rbio = SSL_get_rbio(c->ssl_handle);
+      BIO* wbio = SSL_get_wbio(c->ssl_handle);
+      if (rbio) {
+        BIO_set_read_buffer_size(rbio, value);
+      }
+      if (wbio) {
+        BIO_set_write_buffer_size(wbio, value);
+      }
     }
     return true;
   default:

--- a/runtime/resumable.cpp
+++ b/runtime/resumable.cpp
@@ -653,8 +653,6 @@ bool wait_without_result_synchronously_safe(int64_t resumable_id) {
 }
 
 static bool wait_forked_resumable(int64_t resumable_id, double dead_line_time) {
-  php_assert(dead_line_time > get_precise_now()); // TODO remove asserts
-  php_assert(in_main_thread());                   // TODO remove asserts
   php_assert(is_forked_resumable_id(resumable_id));
 
   forked_resumable_info* resumable = get_forked_resumable_info(resumable_id);
@@ -686,7 +684,7 @@ static bool wait_forked_resumable(int64_t resumable_id, double dead_line_time) {
 }
 
 static bool wait_started_resumable(int64_t resumable_id) noexcept {
-  php_assert(in_main_thread()); // TODO remove asserts
+  php_assert(in_main_thread());
   php_assert(is_started_resumable_id(resumable_id));
 
   started_resumable_info* resumable = get_started_resumable_info(resumable_id);
@@ -1046,8 +1044,8 @@ bool f$wait_queue_empty(int64_t queue_id) {
 }
 
 static void wait_queue_next(int64_t queue_id, double timeout) {
-  php_assert(timeout > get_precise_now()); // TODO remove asserts
-  php_assert(in_main_thread());            // TODO remove asserts
+  php_assert(timeout > get_precise_now());
+  php_assert(in_main_thread());
   php_assert(is_wait_queue_id(queue_id));
 
   wait_queue* q = get_wait_queue(queue_id);

--- a/runtime/streams.cpp
+++ b/runtime/streams.cpp
@@ -320,9 +320,15 @@ Optional<int64_t> f$stream_select(mixed& read, mixed& write, mixed& except, cons
     return false;
   }
 
-  // TODO use pselect
+  struct timespec ts, *timeout_ts = nullptr;
+  if (timeout) {
+    ts.tv_sec = timeout->tv_sec;
+    ts.tv_nsec = static_cast<long>(timeout->tv_usec) * 1000;
+    timeout_ts = &ts;
+  }
+
   dl::enter_critical_section(); // OK
-  int32_t select_result = select(nfds + 1, &rfds, &wfds, &efds, timeout);
+  int32_t select_result = pselect(nfds + 1, &rfds, &wfds, &efds, timeout_ts, nullptr);
   dl::leave_critical_section();
 
   if (select_result == -1) {

--- a/tests/cpp/runtime/runtime-tests.cmake
+++ b/tests/cpp/runtime/runtime-tests.cmake
@@ -21,7 +21,8 @@ prepend(RUNTIME_TESTS_SOURCES ${BASE_DIR}/tests/cpp/runtime/
         memory_resource/unsynchronized_pool_resource-test.cpp
         string-list-test.cpp
         string-test.cpp
-        zstd-test.cpp)
+        zstd-test.cpp
+        stream-select-test.cpp)
 
 allow_deprecated_declarations_for_apple(${BASE_DIR}/tests/cpp/runtime/inter-process-mutex-test.cpp)
 vk_add_unittest(runtime "${RUNTIME_LIBS};${RUNTIME_LINK_TEST_LIBS}" ${RUNTIME_TESTS_SOURCES})

--- a/tests/cpp/runtime/stream-select-test.cpp
+++ b/tests/cpp/runtime/stream-select-test.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include "runtime/streams.h"
+#include "runtime/critical_section.h"
+
+TEST(stream_select, udp_writable) {
+  mixed err_no;
+  mixed err_desc;
+  Stream udp_stream = f$stream_socket_client(
+      CONST_STRING("udp://127.0.0.1:9"), err_no, err_desc, 1.0);
+
+  ASSERT_TRUE(f$boolval(udp_stream));
+
+  mixed read_arr = array<Stream>();
+  mixed write_arr = array<Stream>::create(udp_stream);
+  mixed except_arr = array<Stream>();
+
+  Optional<int64_t> res = f$stream_select(read_arr, write_arr, except_arr, 0, 0);
+  ASSERT_TRUE(res.has_value());
+  ASSERT_EQ(res.val(), 1);
+
+  f$fclose(udp_stream);
+}


### PR DESCRIPTION
## Summary
- rely on `date_default_timezone_get` for default timezone
- expose read/write buffer tuning in SSL streams
- remove leftover debug assertions
- implement no-op `clearstatcache`
- use `pselect` in `stream_select`
- add runtime test for UDP stream_select

## Testing
- `cmake .. -DDOWNLOAD_MISSING_LIBRARIES=On` *(fails: unable to download fmt due to CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_687e5f413a2883278a435a0955e61521